### PR TITLE
fixed: last file terminating newline

### DIFF
--- a/project-template/Text/ProjectTemplate.hs
+++ b/project-template/Text/ProjectTemplate.hs
@@ -100,7 +100,7 @@ unpackTemplate perFile fixLine =
                     start
 
     binaryLoop = do
-        await >>= maybe (return ()) go
+        await >>= maybe (yield "\n") go
       where
         go t =
             case getFileName t of
@@ -109,7 +109,7 @@ unpackTemplate perFile fixLine =
                     yield $ encodeUtf8 t
                     binaryLoop
     textLoop isFirst =
-        await >>= maybe (return ()) go
+        await >>= maybe (yield "\n") go
       where
         go t =
             case getFileName t of

--- a/project-template/test/Text/ProjectTemplateSpec.hs
+++ b/project-template/test/Text/ProjectTemplateSpec.hs
@@ -27,7 +27,12 @@ spec = do
                      .| createTemplate
                      .| unpackTemplate receiveMem id
             let m'' = Map.fromList $ map (second $ mconcat . L.toChunks) $ Map.toList m'
-            m `shouldBe` m''
+            -- ignore posix end newline
+                trimEnd s = case S.stripSuffix "\n" s of
+                                Nothing -> s
+                                Just ss -> trimEnd ss
+                trimBodyEnd = Map.map trimEnd
+            trimBodyEnd m `shouldBe` trimBodyEnd m''
     describe "binaries" $ do
         prop "works with multilines" $ \words' -> do
             let bs = S.pack words'
@@ -35,6 +40,22 @@ spec = do
                 content = "{-# START_FILE BASE64 foo #-}\n" `mappend` encoded
             m <- execWriterT $ runConduit $ yield content .| unpackTemplate receiveMem id
             Map.lookup "foo" m `shouldBe` Just (L.fromChunks [bs])
+        prop "works with multifile" $ \words' -> do
+            let bs = S.pack words'
+                encoded = B64.joinWith "\n" 5 $ B64.encode bs
+                fooContent = "{-# START_FILE BASE64 foo #-}\n" `mappend` encoded
+                barContent = "{-# START_FILE BASE64 bar #-}\n" `mappend` encoded
+            m <- execWriterT $ runConduit $
+                (yield fooContent >> yield barContent) .| unpackTemplate receiveMem id
+            Map.lookup "foo" m `shouldBe` Just (L.fromChunks [bs])
+            Map.lookup "bar" m `shouldBe` Just (L.fromChunks [bs])
+    describe "POSIX file end of newline" $
+        it "new-template" $ do
+            newTemplate <- S.readFile "test/new-template.hsfiles"
+            m <- execWriterT $ runConduit $ yield newTemplate .| unpackTemplate receiveMem id
+            ("\n" `L.isSuffixOf`) <$> Map.elems m `shouldSatisfy` and
+            -- don't repeat newline
+            ("\n\n" `L.isSuffixOf`) <$> Map.elems m `shouldSatisfy` not . or
 
 newtype Helper = Helper (Map.Map FilePath S.ByteString)
     deriving (Show, Eq)

--- a/project-template/test/new-template.hsfiles
+++ b/project-template/test/new-template.hsfiles
@@ -1,0 +1,118 @@
+{-# START_FILE package.yaml #-}
+name:                {{name}}
+version:             0.1.0.0
+github:              "{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}"
+license:             BSD3
+author:              "{{author-name}}{{^author-name}}Author name here{{/author-name}}"
+maintainer:          "{{author-email}}{{^author-email}}example@example.com{{/author-email}}"
+copyright:           "{{copyright}}{{^copyright}}{{year}}{{^year}}2018{{/year}} {{author-name}}{{^author-name}}Author name here{{/author-name}}{{/copyright}}"
+
+extra-source-files:
+- README.md
+- ChangeLog.md
+
+# Metadata used when publishing your package
+# synopsis:            Short description of your package
+# category:            {{category}}{{^category}}Web{{/category}}
+
+# To avoid duplicated efforts in documentation and dealing with the
+# complications of embedding Haddock markup inside cabal files, it is
+# common to point users to the README.md file.
+description:         Please see the README on Github at <https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme>
+
+dependencies:
+- base >= 4.7 && < 5
+
+library:
+  source-dirs: src
+
+executables:
+  {{name}}-exe:
+    main:                Main.hs
+    source-dirs:         app
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - {{name}}
+
+tests:
+  {{name}}-test:
+    main:                Spec.hs
+    source-dirs:         test
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - {{name}}
+
+{-# START_FILE Setup.hs #-}
+import Distribution.Simple
+main = defaultMain
+
+{-# START_FILE test/Spec.hs #-}
+main :: IO ()
+main = putStrLn "Test suite not yet implemented"
+
+{-# START_FILE src/Lib.hs #-}
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"
+
+{-# START_FILE app/Main.hs #-}
+module Main where
+
+import Lib
+
+main :: IO ()
+main = someFunc
+
+{-# START_FILE README.md #-}
+# {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+## Unreleased changes
+
+{-# START_FILE LICENSE #-}
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2018{{/year}}
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+{-# START_FILE .gitignore #-}
+.stack-work/
+{{name}}.cabal
+*~


### PR DESCRIPTION
From [POSIX](http://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap03.html#tag_03_392).
Text file terminating newline.
project-template had bug to no newline last file of hsfiles.
Because, files split by two newline.
But, last file have one newline, Do not two newline.
This commit compatibility omit existing hsfiles.
hsfiles last file do not need to have two newline, and get POSIX text file by this commit.